### PR TITLE
Use CachedImageProvider and add news & icon list safety checks

### DIFF
--- a/lib/ui/home/Home.dart
+++ b/lib/ui/home/Home.dart
@@ -82,6 +82,6 @@ class _HomePageState extends State<Home> {
             ),
             itemCount: news?.length,
             itemBuilder: (BuildContext context, int position) =>
-                NewsRow(news[position])),
+              news != null && news.length > position ? NewsRow(news[position]) : null),
       );
 }

--- a/lib/ui/home/NewsRow.dart
+++ b/lib/ui/home/NewsRow.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 import 'dart:convert';
+import 'package:cached_network_image/cached_network_image.dart';
 import 'package:http/http.dart' as http;
 import 'package:flutter/material.dart';
 import 'package:news_reader/model/IconsResponse.dart';
@@ -54,15 +55,16 @@ class _NewsRowState extends State<NewsRow> {
   @override
   Widget build(BuildContext context) {
     CircleAvatar channelLogo(var url) {
-      try {
-        return new CircleAvatar(
-          backgroundImage: new NetworkImage(icons[1].url),
-        );
-      } catch (Exception) {
-        return new CircleAvatar(
-          child: new Icon(Icons.library_books),
-        );
+      if (icons.isNotEmpty) {
+        try {
+            return new CircleAvatar(
+              backgroundImage: new CachedNetworkImageProvider(icons[1].url),
+            );
+        } catch (Exception) {}
       }
+      return new CircleAvatar(
+        child: new Icon(Icons.library_books),
+      );
     }
 
     final newsCard = Container(

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -14,7 +14,7 @@ packages:
       name: args
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.4.4"
+    version: "1.5.0"
   async:
     dependency: transitive
     description:
@@ -78,6 +78,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "5.5.5"
+  cached_network_image:
+    dependency: "direct main"
+    description:
+      name: cached_network_image
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.4.2"
   charcode:
     dependency: transitive
     description:
@@ -105,7 +112,7 @@ packages:
       name: collection
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.14.6"
+    version: "1.14.11"
   convert:
     dependency: transitive
     description:
@@ -126,7 +133,7 @@ packages:
       name: csslib
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.14.4+1"
+    version: "0.14.5"
   cupertino_icons:
     dependency: "direct main"
     description:
@@ -160,6 +167,13 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_cache_manager:
+    dependency: transitive
+    description:
+      name: flutter_cache_manager
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.1.2"
   flutter_test:
     dependency: "direct dev"
     description: flutter
@@ -171,7 +185,7 @@ packages:
       name: flutter_webview_plugin
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.6"
+    version: "0.2.1+2"
   front_end:
     dependency: transitive
     description:
@@ -199,7 +213,7 @@ packages:
       name: html
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.13.3+2"
+    version: "0.13.3+3"
   http:
     dependency: transitive
     description:
@@ -283,14 +297,14 @@ packages:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.2+1"
+    version: "0.12.3+1"
   meta:
     dependency: transitive
     description:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.5"
+    version: "1.1.6"
   mime:
     dependency: transitive
     description:
@@ -333,6 +347,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.6.2"
+  path_provider:
+    dependency: transitive
+    description:
+      name: path_provider
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.4.1"
   plugin:
     dependency: transitive
     description:
@@ -368,6 +389,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.0.0+1"
+  shared_preferences:
+    dependency: transitive
+    description:
+      name: shared_preferences
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.4.3"
   shelf:
     dependency: transitive
     description:
@@ -395,7 +423,7 @@ packages:
       name: shelf_web_socket
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.2+3"
+    version: "0.2.2+4"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -456,7 +484,14 @@ packages:
       name: string_scanner
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.3"
+    version: "1.0.4"
+  synchronized:
+    dependency: transitive
+    description:
+      name: synchronized
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.5.3"
   term_glyph:
     dependency: transitive
     description:
@@ -470,21 +505,21 @@ packages:
       name: test
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.41"
+    version: "1.3.0"
   timeago:
     dependency: "direct main"
     description:
       name: timeago
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.7"
+    version: "1.3.0"
   typed_data:
     dependency: transitive
     description:
       name: typed_data
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.5"
+    version: "1.1.6"
   utf:
     dependency: transitive
     description:
@@ -492,6 +527,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.9.0+5"
+  uuid:
+    dependency: transitive
+    description:
+      name: uuid
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.0.3"
   vector_math:
     dependency: transitive
     description:
@@ -528,4 +570,5 @@ packages:
     source: hosted
     version: "2.1.15"
 sdks:
-  dart: ">=2.0.0-dev.65 <=2.0.0-dev.69.3.flutter-937ee2e8ca"
+  dart: ">=2.0.0 <3.0.0"
+  flutter: ">=0.1.4 <2.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,9 +10,9 @@ dependencies:
   cupertino_icons: ^0.1.2
   json_annotation: ^0.2.3
   fluro: ^1.1.0
-  flutter_webview_plugin: ^0.1.6
+  flutter_webview_plugin: ^0.2.1+2
   timeago: ^1.2.0
-
+  cached_network_image: ^0.4.2
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
### PR addresses issue [#1](https://github.com/xsahil03x/Flutter-News-Reader/issues/1)

Replaced the ImageProvider with a CachedImageProvider.

Required updating one other dependency, but analyzer didn't show any issues doing so.